### PR TITLE
Handle (quote-syntax _ #:local)

### DIFF
--- a/macro-debugger-text-lib/macro-debugger/analysis/private/get-references.rkt
+++ b/macro-debugger-text-lib/macro-debugger/analysis/private/get-references.rkt
@@ -50,7 +50,8 @@
   (define (analyze/quote-syntax qs-stx)
     (let ([phases (for/list ([offset '(0 1 -1 2 -2)]) (+ (phase) offset))]
           [stx (syntax-case qs-stx ()
-                 [(_quote-syntax x) #'x])])
+                 [(_quote-syntax x) #'x]
+                 [(_quote-syntax x #:local) #'x])])
       (define (add*! id)
         (add-refs! (for/list ([p (in-list phases)])
                      (ref p id 'quote-syntax (identifier-binding id p)))))


### PR DESCRIPTION
```
$ cat /tmp/foo.rkt
#lang typed/racket/base
(define-type Foo Any)

$ raco check-requires /tmp/foo.rkt
(file "/tmp/foo.rkt"):
ERROR in (file "/tmp/foo.rkt")
/Applications/Racket_v6.7/share/pkgs/typed-racket-lib/typed-racket/typecheck/internal-forms.rkt:190:8: quote-syntax: bad syntax
  in: (quote-syntax (define-type-alias-internal Foo Any ()) #:local)
  context...:
   f183
   /Applications/Racket_v6.7/share/pkgs/macro-debugger-text-lib/macro-debugger/analysis/private/get-references.rkt:23:2: recur
   /Applications/Racket_v6.7/share/pkgs/macro-debugger-text-lib/macro-debugger/analysis/private/get-references.rkt:23:2: recur
--------8<-------
```

On Slack @samth said this is probably because a `syntax-case` wasn't updated to know about (and ignore) the `#:local` option to `quote-syntax`.

**CAVEAT**: I hacked my local `get-references.rkt` and it seemed to fix the problem. I'm using GitHub to make the same edit online and create this PR. I feel really lazy doing it this way, but it's all I have time to do right now. I hope it's slightly more helpful than just filing an issue. Anyway please review!